### PR TITLE
fix: response data structure to allow status.

### DIFF
--- a/app/src/api/v1/dao/dao.ts
+++ b/app/src/api/v1/dao/dao.ts
@@ -4,7 +4,7 @@ export function fetchEntry (id: string, queryData: QueryData): Entry {
   return {};
 }
 export function deleteEntry (id: string, queryData: QueryData): QueryData{
-  return {entryId: "0", status: "deleted"};
+  return {entryId: "0", status: { code: 0, comment: "delete success"}};
 }
 export function writeEntry (id: string, entry: Entry): Entry {
   return {};

--- a/app/src/api/v1/helper/image.ts
+++ b/app/src/api/v1/helper/image.ts
@@ -1,5 +1,5 @@
 import { ReceiptReply } from "../state";
 
 export function saveReceipt (id: string, pictureBuf: Buffer): ReceiptReply {
-  return {receiptUrl: ""};
+  return {receiptUrl: "", status: {code: 0}};
 }

--- a/app/src/api/v1/state.ts
+++ b/app/src/api/v1/state.ts
@@ -17,10 +17,16 @@ export interface Transaction {
 export interface ReceiptReply {
   entry?: Entry;
   receiptUrl: string;
+  status: Status;
+}
+
+export interface Status {
+  code: number;
+  comment?: string;
 }
 
 export interface QueryData {
   entryId: string;
-  status?: string;
   detail?: string;
+  status?: Status;
 }

--- a/app/src/api/v1/state.ts
+++ b/app/src/api/v1/state.ts
@@ -21,6 +21,10 @@ export interface ReceiptReply {
 }
 
 export interface Status {
+  /**
+   * code: numeric representation following Unix return - 0 is success
+   * comment: any additional information that may be useful for UX
+   */
   code: number;
   comment?: string;
 }

--- a/app/src/api/v1/state.ts
+++ b/app/src/api/v1/state.ts
@@ -1,11 +1,12 @@
 import Koa from 'koa';
 
-export interface Entry {
-  id?: string;
-  date?: Date;
-  payee?: string;
-  transactions?: Transaction[];
-  comments?: string[];
+export interface Status {
+  /**
+   * code: numeric representation following Unix return - 0 is success
+   * comment: any additional information that may be useful for UX
+   */
+  code: number;
+  comment?: string;
 }
 
 export interface Transaction {
@@ -14,19 +15,18 @@ export interface Transaction {
   unit: string;
 }
 
+export interface Entry {
+  id?: string;
+  date?: Date;
+  payee?: string;
+  transactions?: Transaction[];
+  comments?: string[];
+}
+
 export interface ReceiptReply {
   entry?: Entry;
   receiptUrl: string;
   status: Status;
-}
-
-export interface Status {
-  /**
-   * code: numeric representation following Unix return - 0 is success
-   * comment: any additional information that may be useful for UX
-   */
-  code: number;
-  comment?: string;
 }
 
 export interface QueryData {


### PR DESCRIPTION
fix #5 
# Detail
This PR modifies communication data structure to include request status.

# Caveat
Data structure may have too many optional elements, making them less effective.  It might be better to separate Response and Request data types of each different communication, extending from basetypes as needed.